### PR TITLE
Fixes for Legion sub-build

### DIFF
--- a/cmake/Modules/legate_core_options.cmake
+++ b/cmake/Modules/legate_core_options.cmake
@@ -75,6 +75,7 @@ if(NOT Legion_MAX_FIELDS MATCHES "^(32|64|128|256|512|1024|2048|4096)$")
   message(FATAL_ERROR "The maximum number of Legate fields must be a power of 2 between 32 and 4096 inclusive")
 endif()
 
+
 option(legate_core_STATIC_CUDA_RUNTIME "Statically link the cuda runtime library" OFF)
 option(legate_core_EXCLUDE_LEGION_FROM_ALL "Exclude Legion targets from legate.core's 'all' target" OFF)
 


### PR DESCRIPTION
Fixes for two subtle issues around Legion. These issues only occur when re-configuring, not on the initial configure.

* Legion_DIR gets set to -NOTFOUND on the initial configure, which was then triggering a REQUIRED on re-configure since it was only checking DEFINED rather than the Boolean-ness. The changes ensure that re-configuring does not trigger an error.
* Legion_MAX_DIM and Legion_MAX_FIELDS ended up with different values after re-configure due to subtleties with `set()` and `option()`.